### PR TITLE
Adds lint, checkstyle & test Buildkite jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,10 @@ steps:
     artifact_paths:
       - "**/build/reports/lint-results.*"
       - "**/build/reports/checkstyle/checkstyle.*"
+
+  - label: "Test"
+    plugins:
+      - *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+common-params:
+  &docker-container
+  docker#v3.8.0:
+    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+
+steps:
+  - label: "Lint & Checkstyle"
+    plugins:
+      - *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew lint checkstyle
+    artifact_paths:
+      - "**/build/reports/lint-results.*"
+      - "**/build/reports/checkstyle/checkstyle.*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,9 +9,9 @@ steps:
       - *docker-container
     command: |
       cp gradle.properties-example gradle.properties
-      ./gradlew lint checkstyle
+      ./gradlew lintRelease checkstyle
     artifact_paths:
-      - "**/build/reports/lint-results.*"
+      - "**/build/reports/lint-results**.*"
       - "**/build/reports/checkstyle/checkstyle.*"
 
   - label: "Test"

--- a/gradle.properties-example
+++ b/gradle.properties-example
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
This PR adds lint, checkstyle & test Buildkite jobs. The lint & checkstyle artifacts can be accessed from the `Artifacts` tab in the Buildkite job.