### PR TITLE
Publish to s3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ common-params:
 
 steps:
   - label: "Lint & Checkstyle"
+    key: "lint_and_checkstyle"
     plugins:
       - *docker-container
     command: |
@@ -15,8 +16,21 @@ steps:
       - "**/build/reports/checkstyle/checkstyle.*"
 
   - label: "Test"
+    key: "test"
     plugins:
       - *docker-container
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew test
+
+  - label: "Publish to S3 Maven"
+    depends_on:
+      - "lint_and_checkstyle"
+      - "test"
+    plugins:
+      - *docker-container
+    command: |
+      cp gradle.properties-example gradle.properties
+      ./gradlew \
+          prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+          publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,12 @@ common-params:
   &docker-container
   docker#v3.8.0:
     image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+    propagate-environment: true
+    environment:
+      # DO NOT MANUALLY SET THESE VALUES!
+      # They are passed from the Buildkite agent to the Docker container
+      - "AWS_ACCESS_KEY"
+      - "AWS_SECRET_KEY"
 
 steps:
   - label: "Lint & Checkstyle"

--- a/README.adoc
+++ b/README.adoc
@@ -5,18 +5,41 @@ image::/sample/src/main/res/drawable/logo_144.png[alt text]
 https://tumblr.github.io/PermissMe/java-docs.html[JavaDocs]
 
 ## Gradle
-```
-compile 'com.tumblr.permissme:permissme:1.0.0'
+```groovy
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                url "https://a8c-libs.s3.amazonaws.com/android"
+            }
+        }
+        filter {
+            includeModule "com.tumblr", "permissme"
+        }
+    }
+}
+
+dependencies {
+    implementation 'com.tumblr:permissme:1.1.0'
+}
 ```
 
 ## Maven
 ```
 <dependency>
-  <groupId>com.tumblr.permissme</groupId>
+  <groupId>com.tumblr</groupId>
   <artifactId>permissme</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
+
+## Publishing a new version
+
+In the following cases, the CI will publish a new version with the following format to our S3 Maven repo:
+
+* For each commit in an open PR: `<PR-number>-<commit full SHA1>`
+* Each time a PR is merged to `master`: `master-<commit full SHA1>`
+* Each time a new tag is created: `{tag-name}`
 
 == Introduction
 PermissMe is a convenience library for handling callbacks and operations pertaining to granting access to runtime

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ project.afterEvaluate {
             PermissMePublication(MavenPublication) {
                 from components.release
 
-                groupId "com.tumblr.permissme"
+                groupId "com.tumblr"
                 artifactId "permissme"
                 artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
                 // version is set by 'publish-to-s3' plugin

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,5 @@
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.0'
-    }
+plugins {
+    id "com.android.library"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,11 @@
 plugins {
     id "com.android.library"
+    id "com.automattic.android.publish-to-s3"
 }
 
 repositories {
     google()
     jcenter()
-}
-
-ext {
-    versionCode = 1
-    versionName = "1.0-beta"
 }
 
 apply plugin: 'com.android.library'
@@ -21,8 +17,6 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 31
-        versionCode project.versionCode
-        versionName project.versionName
     }
     buildTypes {
         release {
@@ -62,3 +56,17 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4-rule:1.6.5'
 }
 
+project.afterEvaluate {
+    publishing {
+        publications {
+            PermissMePublication(MavenPublication) {
+                from components.release
+
+                groupId "com.tumblr.permissme"
+                artifactId "permissme"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
+                // version is set by 'publish-to-s3' plugin
+            }
+        }
+   }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+    id "com.android.application"
+}
 
 android {
     compileSdkVersion 31

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,16 @@ pluginManagement {
     plugins {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
         google()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,20 @@
+pluginManagement {
+    gradle.ext.agpVersion = '7.1.0'
+
+    plugins {
+        id "com.android.application" version gradle.ext.agpVersion
+        id "com.android.library" version gradle.ext.agpVersion
+    }
+    repositories {
+        google {
+            content {
+                includeGroupByRegex "com.android.*"
+                includeGroupByRegex "com.google.*"
+                includeGroupByRegex "androidx.*"
+            }
+        }
+        mavenCentral()
+    }
+}
+
 include ':sample'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.agpVersion = '7.1.0'
+    gradle.ext.agpVersion = '7.1.1'
 
     plugins {
         id "com.android.application" version gradle.ext.agpVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,13 +6,7 @@ pluginManagement {
         id "com.android.library" version gradle.ext.agpVersion
     }
     repositories {
-        google {
-            content {
-                includeGroupByRegex "com.android.*"
-                includeGroupByRegex "com.google.*"
-                includeGroupByRegex "androidx.*"
-            }
-        }
+        google()
         mavenCentral()
     }
 }


### PR DESCRIPTION
This PR adds support for publishing the library artifacts to S3 Maven. It also uses this opportunity to add support for [Plugin DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block). I considered making this change as a separate PR, but Android Gradle Plugin is the only plugin used in the project, so the extra effort didn't seem worth it. Having said that, I am happy to separate it into its own PR if it's preferred by the reviewers.

* There is now a new CI step to publish the library artifacts. This step depends on "Lint & Checkstyle" and "Test" tasks. The step uses a script we have in the Docker image to pass Buildkite environment information to the `prepareToPublishToS3` task.
* The publishing is done by [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html). We use [our own Gradle plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) to simplify its setup and have consistency across libraries. This plugin is the one that adds the [prepareToPublishToS3](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/PrepareToPublishToS3Task.kt) task which calculates the version, updates the information for maven-publish plugin and verifies that the version is not already published.
* For the artifact path, I initially implemented it to use the path given in this library's README which was `com.tumblr.permissme:permissme`. However, while working on the Tumblr app integration, I realized it used `com.tumblr:permissme` instead which is a lot more inline with the setup we have for our other libraries, so I decided to match that one instead.
* The specified version information is removed from `build.gradle` as this is now dynamically calculated at the time of publishing.
* We now publish the `-sources.jar` file which is helpful in navigating to the source code within the IDE.

**README Updates**
* For the `repositories` section, it recommends using [exclusiveContent](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.html) syntax which makes the S3 Maven the only possible repository to fetch the `PermissMe` library artifacts. This is an extra security measure to guard against dependency hijacking attacks.
* Information about how to publish a new version and how that version will be formatted has been added. Note that Buildkite logs also contain information about the published version.
* After this PR is merged, I think we should create a new `1.1.0` tag. This is why I opted to use this version in the `README`.

**To Test**

There are no testing instructions specific to this PR. However, since this PR builds on #2, #3 & #4, there is a Tumblr client PR that can be used to test the changes made in these PRs and verify that it's correctly published to S3.
