### PR TITLE
Gradle Wrapper Validation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,14 @@ common_params:
     - automattic/bash-cache#2.11.0
 
 steps:
+  - label: "Gradle Wrapper Validation"
+    command: |
+      validate_gradle_wrapper
+    plugins: *common_plugins
+
+  # Wait for Gradle Wrapper to be validated before running any other jobs
+  - wait
+
   - label: "Lint & Checkstyle"
     key: "lint_and_checkstyle"
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,19 +1,12 @@
-common-params:
-  &docker-container
-  docker#v3.8.0:
-    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
-    propagate-environment: true
-    environment:
-      # DO NOT MANUALLY SET THESE VALUES!
-      # They are passed from the Buildkite agent to the Docker container
-      - "AWS_ACCESS_KEY"
-      - "AWS_SECRET_KEY"
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#2.11.0
 
 steps:
   - label: "Lint & Checkstyle"
     key: "lint_and_checkstyle"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew lintRelease checkstyle
@@ -23,8 +16,7 @@ steps:
 
   - label: "Test"
     key: "test"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew test
@@ -33,8 +25,7 @@ steps:
     depends_on:
       - "lint_and_checkstyle"
       - "test"
-    plugins:
-      - *docker-container
+    plugins: *common_plugins
     command: |
       cp gradle.properties-example gradle.properties
       ./gradlew \

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: "Validate Gradle Wrapper"
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
In https://github.com/Automattic/bash-cache-buildkite-plugin/pull/34 we introduced our own script to validate the Gradle Wrapper which uses the [official documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html#manually_verifying_the_gradle_wrapper_jar) for its implementation. This PR uses that script to add a prerequisite step to validate the Gradle Wrapper in Buildkite.

The main reason we decided to add our own script as opposed to using the official Github Action was to be able to validate the Gradle Wrapper before running any of the Buildkite steps. As discussed in that PR, there are some edge cases our script doesn't cover. Furthermore, because it's a custom implementation, there is always a chance that it gets outdated. Therefore, we are adding the official Github Action alongside our own script.

After this PR is merged, I suggest we add the Github Action as a required step for trunk branch. The Buildkite step is already a prerequisite for the rest of the steps, so I don't think we need to add it as a required check, but having the Github Action as a required check should give us some extra peace of mind. Github only takes ~20s to validate the wrapper, so it shouldn't block developers unless there is an issue with it.

---

Note that in order to use the `bash-cache-buildkite-plugin`, this PR also switches Buildkite builds from Docker to Android AMI. This is a change we have made in most of our repositories, but this is one of the repositories that was left behind.

---

**To Test**
Verify that the Gradle Wrapper Validation is added as a prerequisite step to the Buildkite pipeline.
